### PR TITLE
fix(u-image): load error 回调参数支持 event

### DIFF
--- a/uview-ui/components/u-image/u-image.vue
+++ b/uview-ui/components/u-image/u-image.vue
@@ -194,16 +194,16 @@ export default {
 			this.$emit('click');
 		},
 		// 图片加载失败
-		onErrorHandler() {
+		onErrorHandler(e) {
 			this.loading = false;
 			this.isError = true;
-			this.$emit('error');
+			this.$emit('error', e);
 		},
 		// 图片加载完成，标记loading结束
-		onLoadHandler() {
+		onLoadHandler(e) {
 			this.loading = false;
 			this.isError = false;
-			this.$emit('load');
+			this.$emit('load', e);
 			// 如果不需要动画效果，就不执行下方代码，同时移除加载时的背景颜色
 			// 否则无需fade效果时，png图片依然能看到下方的背景色
 			if (!this.fade) return this.removeBgColor();


### PR DESCRIPTION
有些图片是不知道宽高的，所以需要在 load 事件回调中回传 event 参数。

```vue
<u-image  src="unknow-size.png"  @load="handleImageLoaded($event, id)" />

handleImageLoaded(e, id) {
  console.log(e.detail.width, e.detail.height, id)
},
```